### PR TITLE
[Fix] Allow missing solution file

### DIFF
--- a/src/ProjectDiff.Core/Entrypoints/SolutionProjectGraphEntryPointProvider.cs
+++ b/src/ProjectDiff.Core/Entrypoints/SolutionProjectGraphEntryPointProvider.cs
@@ -26,8 +26,8 @@ public sealed class SolutionProjectGraphEntryPointProvider : IProjectGraphEntryP
     {
         if (!fs.FileExists(_solution.FullName))
         {
-            _logger.LogError("Could not find the solution file {SolutionFile} in the file system", _solution.FullName);
-            throw new FileNotFoundException("Could not find the solution file in the file system", _solution.FullName);
+            _logger.LogWarning("Could not find the solution file {SolutionFile} in the file system, assuming empty", _solution.FullName);
+            return [];
         }
 
         await using var stream = fs.GetFileStream(

--- a/src/dotnet-proj-diff/ProjectDiffCommand.cs
+++ b/src/dotnet-proj-diff/ProjectDiffCommand.cs
@@ -35,10 +35,6 @@ public sealed class ProjectDiffCommand : RootCommand
                 {
                     x.AddError("{x.Argument.Name} must be specified");
                 }
-                else if (!f.Exists)
-                {
-                    x.AddError($"File '{f.FullName}' does not exist.");
-                }
                 else if (f.Extension is not (".sln" or ".slnx"))
                 {
                     x.AddError($"File '{f.FullName}' is not a valid sln file.");

--- a/test/ProjectDiff.Tests/Tool/ProjectDiffTests.NewSolutionMarksProjectAsAdded.verified.txt
+++ b/test/ProjectDiff.Tests/Tool/ProjectDiffTests.NewSolutionMarksProjectAsAdded.verified.txt
@@ -1,0 +1,7 @@
+﻿[
+  {
+    path: Sample/Sample.csproj,
+    name: Sample,
+    status: Added
+  }
+]

--- a/test/ProjectDiff.Tests/Tool/ProjectDiffTests.cs
+++ b/test/ProjectDiff.Tests/Tool/ProjectDiffTests.cs
@@ -337,6 +337,24 @@ public sealed class ProjectDiffTests
         await VerifyJson(output);
     }
 
+    [Fact]
+    public async Task NewSolutionMarksProjectAsAdded()
+    {
+
+        using var repo = await TestRepository.SetupAsync(static async r =>
+            {
+                r.CreateDirectory("Sample");
+                r.CreateProject("Sample/Sample.csproj");
+                await r.WriteAllTextAsync("Sample/MyClass.cs", "// Some content");
+            }
+        );
+
+        var sln = await repo.CreateSolutionAsync("Sample.sln", sln => sln.AddProject("Sample/Sample.csproj"));
+
+        var output = await ExecuteAndReadStdout(repo, $"--solution={sln}");
+        await VerifyJson(output);
+    }
+
     private static async Task<string> ExecuteAndReadStdout(
         TestRepository repository,
         params string[] args


### PR DESCRIPTION
Non existent solution files are no longer treated as an error, but rather a warning, this is done to handle cases where a solution file is not present in one of the graphs, but exists in the other graph.

Also allows for solution files that don't exist on the current file system, since the solution could be present in either HEAD or BASE and would be evaluated there.